### PR TITLE
(WIP post travis)INFRASYS-5478 Make all pytomcat tests runable

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -35,7 +35,7 @@ class TomcatIntegrationTestCase(unittest.TestCase):
         self.deploy(apps)
 
     def restart(self):
-        self.tr.deployer.restart()
+        self.tr.restart()
 
     def deploy(self, apps):
         self.tr.deployer.deploy(apps)

--- a/tests/restart_it.py
+++ b/tests/restart_it.py
@@ -15,13 +15,13 @@ class ClusterDeployerIT(TomcatIntegrationTestCase):
 
     def testSimpleRestartWorks(self):
         self.enable_conditional()
-        self.deploy_war('conditional.war', '/conditional')
+        self.deploy_war('conditional.war', '/simple')
         self.restart()
 
     def testMultipleAppRestartWorks(self):
         apps = {}
         self.enable_conditional()
-        self.add_war(apps, 'conditional.war',   '/conditional')
+        self.add_war(apps, 'helo.war',   '/multi1')
         self.add_war(apps, 'goodbye.war', '/multi2')
         self.deploy(apps)
         self.restart()

--- a/tests/tomcatrunner.py
+++ b/tests/tomcatrunner.py
@@ -37,6 +37,9 @@ class TomcatRunner:
         self.__stop_servers()
         self.__remove_homes()
 
+    def restart(self):
+        self.deployer.restart('localhost')
+
     def __validate_tomcat_installation(self):
         for f in [ 'bin/catalina.sh', 'lib/catalina.jar' ]:
             if not os.path.exists(os.path.join(self.tomcat_dir, f)):


### PR DESCRIPTION
1 test failing, possibly because it is in fact not breaking with the property change.
```
mgorman@MGORMAN-MBPR:pytomcat (INFRASYS-5478 %)$ python tests/deployer_it_test.py
.....
----------------------------------------------------------------------
Ran 5 tests in 28.762s

OK
mgorman@MGORMAN-MBPR:pytomcat (INFRASYS-5478 %)$ python tests/parser_test.py
Selftest PASSED
mgorman@MGORMAN-MBPR:pytomcat (INFRASYS-5478 %)$ python tests/warfile_parser_test.py
Selftest OK
mgorman@MGORMAN-MBPR:pytomcat (INFRASYS-5478 %)$ python tests/restart_it_test.py
F..
======================================================================
FAIL: testInvalidWarRaisesError (__main__.ClusterRestartIT)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/restart_it_test.py", line 38, in testInvalidWarRaisesError
    self.assertNotEqual(app['/conditional']['stateName'], 'STARTED')
AssertionError: 'STARTED' == 'STARTED'

----------------------------------------------------------------------
Ran 3 tests in 31.406s

FAILED (failures=1)
```
Bug ticket has been opened to deal with this 1 test as it is possibly to do with the WAR file. 