### PR TITLE
(17.12.0) DEVOPS-8715: Added a configurable timeout for restart function

### DIFF
--- a/tomcat/deployer.py
+++ b/tomcat/deployer.py
@@ -271,7 +271,7 @@ class ClusterDeployer:
         opts = { 'abort_on_error': True, 'threads': threads }
         if hosts:
             opts['hosts'] = hosts
-        rv = self.c.run_command('restart', **opts)
+        rv = self.c.run_command('restart', self.restart_timeout, **opts)
         if rv.has_failures:
             self.log.error("There were failed applications after restart")
             sys.exit(1)

--- a/tomcat/scripts.py
+++ b/tomcat/scripts.py
@@ -45,7 +45,9 @@ def create_option_parser(usage, epilog=None):
 def add_restart_options(parser):
     parser.add_option("--restart-fraction", default=0.33, type="float", dest="restart_fraction",
                       help="Fraction of the cluster nodes rebooted at the same time (e.g. 0.33)")
-    return [ 'restart_fraction' ]
+    parser.add_option("--restart-timeout", default=600, type="int", dest="restart_timeout",
+                      help="Seconds after which restart will timeout")
+    return ['restart_fraction', 'restart_timeout']
 
 def extract_options(keys, opts):
     values = map(lambda x: getattr(opts, x), keys)


### PR DESCRIPTION
Tested by making change to phx_qa_reboot_cluster job and adding the `restart-timeout` param to `functions`. Job passed this time since app took 11 mins to restart.

<img width="1426" alt="screen shot 2017-03-11 at 5 52 33 pm" src="https://cloud.githubusercontent.com/assets/8883916/23828363/245966b2-0684-11e7-8f0d-18229e5c8ded.png">
